### PR TITLE
rename to data.awssso_role

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ resource "aws_ssoadmin_permission_set" "readonly" {
   name         = "ReadOnly"
 }
 
-data "awssso_ssoadmin_role" "readonly" {
+data "awssso_role" "readonly" {
   permission_set_name = aws_ssoadmin_permission_set.readonly.name
 }
 
 output "role" {
   description = "IAM role ARN for the role created by the AWS SSO instance for the AWS organization."
-  value       = data.awssso_ssoadmin_role.sso_readonly.arn
+  value       = data.awssso_role.sso_readonly.arn
 }
 ```

--- a/awssso/data_source_awssso_role.go
+++ b/awssso/data_source_awssso_role.go
@@ -12,9 +12,9 @@ import (
 	"github.com/takescoop/terraform-provider-awssso/awssso/internal/keyvaluetags"
 )
 
-func dataSourceAwsSsoAdminRole() *schema.Resource {
+func dataSourceAwsSsoRole() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceAwsSsoAdminRoleRead,
+		Read: dataSourceAwsSsoRoleRead,
 
 		Schema: map[string]*schema.Schema{
 			"arn": {
@@ -62,7 +62,7 @@ func dataSourceAwsSsoAdminRole() *schema.Resource {
 	}
 }
 
-func dataSourceAwsSsoAdminRoleRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceAwsSsoRoleRead(d *schema.ResourceData, meta interface{}) error {
 	iamconn := meta.(*AWSClient).iamconn
 	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 

--- a/awssso/provider.go
+++ b/awssso/provider.go
@@ -183,7 +183,7 @@ func Provider() *schema.Provider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"awssso_ssoadmin_role": dataSourceAwsSsoAdminRole(),
+			"awssso_role": dataSourceAwsSsoRole(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{},


### PR DESCRIPTION
SSO Admin refers to the [AWS SSO API](https://docs.aws.amazon.com/singlesignon/latest/APIReference/welcome.html), to disambiguate it from accessing SSO as an end user (`aws sso login`). Since this doesn't access the SSO administrative API, it seems like we should omit `ssoadmin` to avoid the implication that this provider relies on the official API. 

This would be v2.0.0.