### PR TITLE
Use fork for import GPG key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 # This GitHub action can publish assets for release when a tag is created.
 # Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.0).
 #
-# This uses an action (hashicorp/ghaction-import-gpg) that assumes you set your 
+# This uses an action (paultyng/ghaction-import-gpg) that assumes you set your
 # private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
 # secret. If you would rather own your own GPG handling, please fork this action
 # or use an alternative one for key handling.
@@ -32,11 +32,10 @@ jobs:
       -
         name: Import GPG key
         id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@v2.1.0
+        uses: paultyng/ghaction-import-gpg@v2.1.0
         env:
-          # These secrets will need to be configured for the repository:
-          GPG_PRIVATE_KEY: ${{ secrets.TF_REGISTRY_GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.TF_REGISTRY_PASSPHRASE }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
@@ -45,5 +44,4 @@ jobs:
           args: release --rm-dist
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-          # GitHub sets this automatically
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Signing the release for publication is [currently broken](https://github.com/TakeScoop/terraform-provider-awssso/runs/2548008583?check_suite_focus=true).

There have been some recent upstream changes that I suspect to be the issue so the fix here reverts back to the [previously recommended publication configuration](https://github.com/hashicorp/terraform-provider-scaffolding/pull/61) to see if we get a successful release.

I don't really know what to make of [hashicorp/ghaction-import-gpg](https://github.com/hashicorp/ghaction-import-gpg). 5 days ago we had a successful release, then it looks like the entire repo was wiped out 4 days ago and replaced with what was there now. 
